### PR TITLE
Migrate to log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ serde_json = "1.0.81"
 rand = "0.8.4"
 colored = "2"
 chrono = "0.4.19"
+log = { version = "0.4.17", features = ["serde"] }
+simple_logger = "2.2.0"

--- a/src/bin/nameserver.rs
+++ b/src/bin/nameserver.rs
@@ -1,14 +1,17 @@
 use ariadne_dns::nameserver::conf::ZoneConf;
 use ariadne_dns::nameserver::*;
+use ariadne_dns::shared::dns;
+use ariadne_dns::shared::log::{init_log, set_max_level};
 use ariadne_dns::shared::net::{start_servers, TcpParams, UdpParams};
-use ariadne_dns::shared::{dns, log};
+use colored::Colorize;
 use std::sync::Arc;
 use std::{env, process, time};
 
 fn main() {
+    init_log();
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
-        log::init_log(log::LogLevel::Debug);
         print_usage();
         process::exit(1);
     }
@@ -16,12 +19,11 @@ fn main() {
     // Process configuration file.
     let conf = match conf::Conf::from_file(&args[1]) {
         Ok(conf) => {
-            log::init_log(conf.log_level);
+            set_max_level(conf.log_level);
             log::info!("Configuration parsed: {:?}.", conf);
             conf
         }
         Err(err) => {
-            log::init_log(log::LogLevel::Debug);
             log::error!("Parsing configuration file: {}", err);
             process::exit(1);
         }

--- a/src/bin/resolver.rs
+++ b/src/bin/resolver.rs
@@ -1,25 +1,26 @@
 use ariadne_dns::resolver::*;
-use ariadne_dns::shared::log;
+use ariadne_dns::shared::log::{init_log, set_max_level};
 use ariadne_dns::shared::net::*;
+use colored::Colorize;
 use std::sync::Arc;
 use std::{env, process, time};
 
 fn main() {
+    init_log();
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
-        log::init_log(log::LogLevel::Debug);
         print_usage();
         process::exit(1);
     }
 
     let conf = match conf::Conf::from_file(&args[1]) {
         Ok(conf) => {
-            log::init_log(conf.log_level);
+            set_max_level(conf.log_level);
             log::info!("Parsed configuration: {:?}.", conf);
             conf
         }
         Err(err) => {
-            log::init_log(log::LogLevel::Debug);
             log::error!("Parsing configuration file: {}", err);
             process::exit(1);
         }

--- a/src/nameserver/conf.rs
+++ b/src/nameserver/conf.rs
@@ -1,4 +1,4 @@
-use crate::shared::{dns, log};
+use crate::shared::dns;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{fs, net};
@@ -6,7 +6,7 @@ use std::{fs, net};
 /// Configuration values obtained parsing the configuration file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Conf {
-    pub log_level: log::LogLevel,
+    pub log_level: log::Level,
     pub udp_server: UdpServerConf,
     pub tcp_server: TcpServerConf,
     pub zone: ZoneConf,

--- a/src/nameserver/handler.rs
+++ b/src/nameserver/handler.rs
@@ -1,7 +1,7 @@
 use crate::nameserver::zones::*;
+use crate::shared::dns;
 use crate::shared::dns::Question;
 use crate::shared::net::*;
-use crate::shared::{dns, log};
 
 /// The nameserver handler able to serve dns requests via its [`DnsHandler`] implementation.
 pub struct NameserverHandler(pub ManagedZone);

--- a/src/nameserver/zones/parser_auth.rs
+++ b/src/nameserver/zones/parser_auth.rs
@@ -2,7 +2,7 @@ use crate::nameserver::zones::errors::*;
 use crate::nameserver::zones::parser::*;
 use crate::nameserver::zones::tokens::*;
 use crate::nameserver::zones::utils::*;
-use crate::shared::{dns, log};
+use crate::shared::dns;
 use std::net;
 use std::str::FromStr;
 

--- a/src/nameserver/zones/parser_sub.rs
+++ b/src/nameserver/zones/parser_sub.rs
@@ -3,7 +3,7 @@ use crate::nameserver::zones::parser::*;
 use crate::nameserver::zones::parser_auth::*;
 use crate::nameserver::zones::tokens::*;
 use crate::nameserver::zones::utils::*;
-use crate::shared::{dns, log};
+use crate::shared::dns;
 
 #[derive(Debug)]
 struct SubParsingState<'a> {

--- a/src/resolver/back_end/cache.rs
+++ b/src/resolver/back_end/cache.rs
@@ -1,4 +1,3 @@
-use crate::shared::log;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};

--- a/src/resolver/conf.rs
+++ b/src/resolver/conf.rs
@@ -1,4 +1,3 @@
-use crate::shared::log;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::net;
@@ -7,7 +6,7 @@ use std::str::FromStr;
 /// Configuration values obtained parsing the configuration file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Conf {
-    pub log_level: log::LogLevel,
+    pub log_level: log::Level,
     pub udp_server: UdpServerConf,
     pub tcp_server: TcpServerConf,
     pub resolver: ResolverConf,

--- a/src/resolver/handler.rs
+++ b/src/resolver/handler.rs
@@ -1,6 +1,5 @@
 use crate::resolver::*;
 use crate::shared::dns;
-use crate::shared::log;
 use crate::shared::net::*;
 
 /// The resolver handler able to serve dns requests via its [`DnsHandler`] implementation.

--- a/src/shared/log.rs
+++ b/src/shared/log.rs
@@ -1,111 +1,41 @@
-pub use crate::debug;
-pub use crate::error;
-pub use crate::info;
-pub use crate::warn;
-use serde::{Deserialize, Serialize};
-use std::sync;
+use self::Level as LogLevel;
+pub use log::Level;
+use simple_logger::SimpleLogger;
 
-static LOG_LEVEL_ONCE: sync::Once = sync::Once::new();
-static mut LOG_LEVEL: LogLevel = LogLevel::Debug;
+// // This remains because log::Level does not implement Ser/De
+// #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialOrd, PartialEq)]
+// pub enum LogLevel {
+//     Debug,
+//     Info,
+//     Warn,
+//     Error,
+// }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialOrd, PartialEq)]
-pub enum LogLevel {
-    Debug,
-    Info,
-    Warn,
-    Error,
+// impl LogLevel {
+//     pub const fn level(self) -> Level {
+//         match self {
+//             LogLevel::Debug => Level::Debug,
+//             LogLevel::Info => Level::Info,
+//             LogLevel::Warn => Level::Warn,
+//             LogLevel::Error => Level::Error,
+//         }
+//     }
+// }
+
+/// Initialize the logging facility with Debug level.
+pub fn init_log() {
+    SimpleLogger::new()
+        .with_level(Level::Debug.to_level_filter())
+        .init()
+        .unwrap()
 }
 
-pub fn init_log(lvl: LogLevel) {
-    if LOG_LEVEL_ONCE.is_completed() {
-        return;
-    }
-    unsafe {
-        LOG_LEVEL_ONCE.call_once(|| {
-            LOG_LEVEL = lvl;
-        });
-    }
+#[inline]
+pub fn set_max_level(lvl: LogLevel) {
+    ::log::set_max_level(lvl.to_level_filter())
 }
 
-pub fn log_level() -> LogLevel {
-    if !LOG_LEVEL_ONCE.is_completed() {
-        panic!("log not initialized");
-    }
-    unsafe { LOG_LEVEL }
-}
-
-#[macro_export]
-macro_rules! debug {
-    ($fmt:expr) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Debug {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "DEBUG".bold().bright_magenta(), $fmt);
-        };
-    }};
-
-    ($fmt:expr, $($arg:tt)*) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Debug {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "DEBUG".bold().bright_magenta(), format!($fmt, $($arg)*));
-        }
-    }}
-}
-
-#[macro_export]
-macro_rules! info {
-    ($fmt:expr) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Info {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "INFO".bold().bright_green(), $fmt);
-        };
-    }};
-
-    ($fmt:expr, $($arg:tt)*) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Info {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "INFO".bold().bright_green(), format!($fmt, $($arg)*));
-        }
-    }}
-}
-
-#[macro_export]
-macro_rules! warn {
-    ($fmt:expr) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Warn {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "WARN".bold().bright_yellow(), $fmt);
-        };
-    }};
-
-    ($fmt:expr, $($arg:tt)*) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Warn {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "WARN".bold().bright_yellow(), format!($fmt, $($arg)*));
-        };
-    }}
-}
-
-#[macro_export]
-macro_rules! error {
-    ($fmt:expr) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Error {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "ERROR".bold().bright_red(), $fmt);
-        };
-    }};
-
-    ($fmt:expr, $($arg:tt)+) => {{
-        use colored::*;
-        if log::log_level() <= log::LogLevel::Error {
-            let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
-            println!("{} {} {}", timestamp, "ERROR".bold().bright_red(), format!($fmt, $($arg)*));
-        };
-    }}
+/// Retrieving the logging level is no longer necessary or possible.
+pub const fn log_level() -> LogLevel {
+    panic!("log_level() is no longer available")
 }

--- a/src/shared/net/setup.rs
+++ b/src/shared/net/setup.rs
@@ -1,4 +1,3 @@
-use crate::shared::log;
 use crate::shared::net::tcp_server::*;
 use crate::shared::net::traits::*;
 use crate::shared::net::udp_server::*;

--- a/src/shared/net/tcp_server.rs
+++ b/src/shared/net/tcp_server.rs
@@ -1,5 +1,5 @@
 use crate::shared::net::traits::*;
-use crate::shared::{dns, log, thread_pool};
+use crate::shared::{dns, thread_pool};
 use std::io::{Read, Write};
 use std::sync::{atomic, Arc};
 use std::{io, net, time};

--- a/src/shared/net/udp_server.rs
+++ b/src/shared/net/udp_server.rs
@@ -1,5 +1,5 @@
 use crate::shared::net::traits::*;
-use crate::shared::{dns, log, thread_pool};
+use crate::shared::{dns, thread_pool};
 use std::sync::{atomic, Arc};
 use std::{io, net, time};
 

--- a/src/shared/thread_pool.rs
+++ b/src/shared/thread_pool.rs
@@ -1,4 +1,3 @@
-use crate::shared::log;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 


### PR DESCRIPTION
This PR migrates the logging facility from `shared::log` into the external `log`
crate.

Some notable side effects of this PR are as follows:

1. The public function `log_level()` is no longer necessary nor necessary.  The `log` crate handles the internals of log level filtering.
2. A new dependency `simple_logger` is needed for the actual logging functionalities.
3. The colors of the logs may not remain the same as the original logging facility, as now the external logging facility selects the color based on the log level.